### PR TITLE
Replacing README reference to private BitBucket repo with GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Assumptions:
 
 ```
 # Connect your git repo to the luggage git repo
-git remote add luggage git@bitbucket.org:isuitc/luggage.git
+git remote add luggage git@github.com:isubit/luggage.git
 # Bring the luggage code in
 git pull luggage master
 # Initialize and retrieve submodules from their own git repos


### PR DESCRIPTION
Replacing README.md reference to private BitBucket repo with the public GitHub repo. Was causing permissions issues when trying to follow the next step "git pull luggage master" because it was referencing a private BitBucket repo I didn't have access to.
